### PR TITLE
Add `super` for `Range#cover?(range)` in Ruby 2.6

### DIFF
--- a/lib/gorilla_patch/cover.rb
+++ b/lib/gorilla_patch/cover.rb
@@ -5,7 +5,7 @@ module GorillaPatch
 	module Cover
 		refine Range do
 			def cover?(value)
-				return super unless value.is_a? Range
+				return super unless value.is_a?(Range) && RUBY_VERSION < '2.6'
 
 				super(value.first) && super(value.last)
 			end

--- a/spec/gorilla_patch/cover_spec.rb
+++ b/spec/gorilla_patch/cover_spec.rb
@@ -4,23 +4,41 @@ describe GorillaPatch::Cover do
 	using GorillaPatch::Cover
 
 	describe Range, '#cover?' do
+		subject { (4..8).cover?(value) }
+
 		context 'with other Range' do
+			before do
+				if RUBY_VERSION >= '2.6'
+					expect(value).not_to receive(:first)
+				else
+					expect(value).to receive(:first).once.and_call_original
+				end
+			end
+
 			context 'that covered' do
-				it { expect((4..8).cover?(5..7)).to be true }
+				let(:value) { 5..7 }
+
+				it { is_expected.to be true }
 			end
 
 			context 'that not covered' do
-				it { expect((4..8).cover?(2..7)).to be false }
+				let(:value) { 2..7 }
+
+				it { is_expected.to be false }
 			end
 		end
 
 		context 'with standard types (Integer)' do
 			context 'that covered' do
-				it { expect((4..8).cover?(5)).to be true }
+				let(:value) { 5 }
+
+				it { is_expected.to be true }
 			end
 
 			context 'that not covered' do
-				it { expect((4..8).cover?(2)).to be false }
+				let(:value) { 2 }
+
+				it { is_expected.to be false }
 			end
 		end
 	end


### PR DESCRIPTION
https://blog.bigbinary.com/2018/10/24/ruby-2-6-range-cover-now-accepts-range-object.html